### PR TITLE
feat(agent-tickets): listar chamados com polling e abrir chat real por ticket

### DIFF
--- a/app/(agent)/chat/page.tsx
+++ b/app/(agent)/chat/page.tsx
@@ -1,118 +1,247 @@
 'use client'
 
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Cookies from "js-cookie";
+import { io, Socket } from "socket.io-client";
 import Speechbubble from "./components/speechbubble/speechbubble";
 import { InputField } from "@/app/components/ui/inputField";
 import { Button } from "@/app/components/ui/button";
 import { Send } from "lucide-react";
-import { useSearchParams } from "next/navigation";
+import { api } from "@/services/api";
+import { decodeToken } from "@/utils/decode-token";
+import { ITicket } from "@/services/ticket/ticket.interface";
 
-export default function Page(){
-    const searchParams = useSearchParams()
-    const ticketId = searchParams.get("id")
+type ChatMessage = {
+    id: string;
+    ticketId: string;
+    senderId: string;
+    senderRole: "CLIENT" | "AGENT" | "ADMIN";
+    content: string;
+    createdAt: string;
+    editedAt?: string | null;
+    deletedAt?: string | null;
+};
 
-    console.log(ticketId)
+export default function Page() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const ticketId = searchParams.get("id");
+
+    const [ticket, setTicket] = useState<ITicket | null>(null);
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
+    const [messageInput, setMessageInput] = useState("");
+    const [authToken, setAuthToken] = useState<string | null>(null);
+    const [currentAgentId, setCurrentAgentId] = useState<string | null>(null);
+    const socketRef = useRef<Socket | null>(null);
+
+    useEffect(() => {
+        const token = Cookies.get("token") || localStorage.getItem("token");
+        if (!token) {
+            return;
+        }
+
+        setAuthToken(token);
+
+        try {
+            const user = decodeToken(token);
+            setCurrentAgentId(user.sub);
+        } catch {
+            setCurrentAgentId(null);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!ticketId) {
+            return;
+        }
+
+        const fetchTicket = async () => {
+            try {
+                const response = await api.get(`/tickets/${ticketId}`);
+                setTicket(response.data);
+            } catch (err) {
+                console.error("Erro ao carregar ticket", err);
+                router.replace("/tickets");
+            }
+        };
+
+        fetchTicket();
+    }, [ticketId, router]);
+
+    useEffect(() => {
+        if (!ticket || !currentAgentId) {
+            return;
+        }
+
+        if (!ticket.agentId || ticket.agentId !== currentAgentId) {
+            router.replace("/tickets");
+        }
+    }, [ticket, currentAgentId, router]);
+
+    useEffect(() => {
+        if (!ticketId || !authToken || !ticket?.agentId) {
+            return;
+        }
+
+        if (currentAgentId && ticket.agentId !== currentAgentId) {
+            return;
+        }
+
+        const baseUrl = api.defaults.baseURL;
+        if (!baseUrl) {
+            console.error("API base URL nao configurada para socket");
+            return;
+        }
+
+        const socket = io(`${baseUrl}/chat`, {
+            auth: { token: authToken },
+        });
+
+        socketRef.current = socket;
+
+        socket.on("connect", () => {
+            socket.emit("joinRoom", { ticketId });
+        });
+
+        socket.on("chatHistory", (history: ChatMessage[]) => {
+            setMessages(history);
+        });
+
+        socket.on("newMessage", (message: ChatMessage) => {
+            setMessages((prev) => [...prev, message]);
+        });
+
+        socket.on("updatedMessage", (message: ChatMessage) => {
+            setMessages((prev) =>
+                prev.map((item) => (item.id === message.id ? message : item))
+            );
+        });
+
+        socket.on("deletedMessage", (message: ChatMessage) => {
+            setMessages((prev) =>
+                prev.map((item) => (item.id === message.id ? message : item))
+            );
+        });
+
+        socket.on("socketError", (payload: { message?: string }) => {
+            console.error(payload?.message ?? "Erro no socket");
+        });
+
+        return () => {
+            socket.disconnect();
+            socketRef.current = null;
+        };
+    }, [ticketId, authToken, ticket?.agentId, currentAgentId]);
+
+    const orderedMessages = useMemo(() => {
+        return [...messages].sort(
+            (a, b) =>
+                new Date(a.createdAt).getTime() -
+                new Date(b.createdAt).getTime()
+        );
+    }, [messages]);
+
+    const handleSend = () => {
+        if (!ticketId) {
+            return;
+        }
+
+        const content = messageInput.trim();
+        if (!content) {
+            return;
+        }
+
+        socketRef.current?.emit("sendMessage", {
+            ticketId,
+            content,
+        });
+
+        setMessageInput("");
+    };
+
+    const handleCloseTicket = async () => {
+        if (!ticketId) {
+            return;
+        }
+
+        try {
+            await api.patch(`/tickets/${ticketId}`, { status: "CLOSED" });
+            socketRef.current?.disconnect();
+            socketRef.current = null;
+            setMessages([]);
+            router.push("/tickets");
+        } catch (err) {
+            console.error("Erro ao concluir ticket", err);
+        }
+    };
 
     return(
         <div className="h-screen flex flex-col items-center bg-white-base">
             <header className="bg-white-500 w-full p-4 flex justify-between shadow-md/15">
                 <h4 className='text-1 align-middle flex items-center'>
-                    Nome do Cliente
+                    {ticket?.client?.name ?? "Cliente"}
                 </h4>
 
                 <div className="flex gap-1.5">
-                    {/* <Button label='Escalonar' className="bg-green-700!"/> */}
-                    <Button label='Concluir' className="bg-black-300!"/>
+                    <Button
+                        label='Concluir'
+                        className="bg-black-300!"
+                        onClick={handleCloseTicket}
+                    />
                 </div>
-
-                
             </header>
 
             <section className="w-full flex-1 overflow-y-auto flex justify-center">
-                
                 <section className="px-2 py-6 flex flex-col gap-1.5 max-w-3xl w-full">
-
-                    <div className="">
+                    <div>
                         <h6 className="label-2">
                             Você está atendendo
                         </h6>
                         <h2 className="subtitle-2">
-                            Nome Cliente
+                            {ticket?.client?.name ?? "Cliente"}
                         </h2>
                         <p className="text-2 mb-6 mt-1">
-                            Funcionário da empresa <b className="text-blue-700">Empresa</b> com problema em <b className="text-blue-700">Segurança</b>
+                            Funcionário da empresa{' '}
+                            <b className="text-blue-700">
+                                {ticket?.company?.name ?? "Empresa"}
+                            </b>{' '}
+                            com problema em{' '}
+                            <b className="text-blue-700">
+                                {ticket?.subject?.name ?? "Assunto"}
+                            </b>
                         </p>
                     </div>
 
-                    <Speechbubble 
-                        sender={false}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iste doloremque at possimus itaque dolorem nam illo error alias, amet voluptate.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={false}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iste doloremque at possimus itaque dolorem nam illo error alias, amet voluptate.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={false}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iste doloremque at possimus itaque dolorem nam illo error alias, amet voluptate.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={false}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iste doloremque at possimus itaque dolorem nam illo error alias, amet voluptate.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={false}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet consectetur adipisicing elit. Iste doloremque at possimus itaque dolorem nam illo error alias, amet voluptate.'
-                    />
-                    <Speechbubble 
-                        sender={true}
-                        message='Lorem ipsum, dolor sit amet.'
-                    />
+                    {orderedMessages.map((message) => (
+                        <Speechbubble
+                            key={message.id}
+                            sender={message.senderId === currentAgentId}
+                            message={
+                                message.deletedAt
+                                    ? "Mensagem removida"
+                                    : message.content
+                            }
+                        />
+                    ))}
                     <br />
                 </section>
-
             </section>
-        
+
             <header className="bg-white-500 w-full px-4 py-3 flex items-center gap-2.5 shadow-[0_-2px_8px_rgba(0,0,0,0.15)]">
-                
-                <InputField placeholder="Digite sua mensagem" className="bg-white-base focus:ring-[var(--blue-300)]!" />
-                
-                <Button icon={Send} type="submit" className="bg-blue-base! rounded-full! aspect-square!"/>
+                <InputField
+                    placeholder="Digite sua mensagem"
+                    className="bg-white-base focus:ring-[var(--blue-300)]!"
+                    value={messageInput}
+                    onChange={(event) => setMessageInput(event.target.value)}
+                />
+
+                <Button
+                    icon={Send}
+                    type="button"
+                    className="bg-blue-base! rounded-full! aspect-square!"
+                    onClick={handleSend}
+                />
             </header>
         </div>
     )

--- a/app/(agent)/tickets/components/groupTable.tsx
+++ b/app/(agent)/tickets/components/groupTable.tsx
@@ -3,13 +3,16 @@
 import { Table } from "antd"
 import { getColumns } from "../tickets.table.config"
 import { api } from "@/services/api"
-import { useState, useEffect } from "react"
+import { useMemo, useState, useEffect } from "react"
 import { ISupportGroupSummary } from "@/services/support-group/support-group.interface"
 import { useRouter } from "next/navigation"
+import Cookies from "js-cookie"
+import { decodeToken } from "@/utils/decode-token"
+import { ITicket } from "@/services/ticket/ticket.interface"
 
 interface GroupTableProps {
     group: ISupportGroupSummary,
-    tickets: any[],
+    tickets: ITicket[],
     description: string,
     onAssign: () => void,
 }
@@ -19,12 +22,29 @@ export default function Page({group, tickets, description, onAssign}: GroupTable
     const [notAssignedTickets, setNotAssignedTickets] = useState(0)
     const router = useRouter()
 
+    const currentAgentId = useMemo(() => {
+        if (typeof window === 'undefined') {
+            return null
+        }
+
+        const token = Cookies.get("token") || localStorage.getItem("token")
+        if (!token) {
+            return null
+        }
+
+        try {
+            return decodeToken(token).sub
+        } catch {
+            return null
+        }
+    }, [])
+
     // Atribui um chamado a si mesmo e da refetch nos tickets
     const handleAssign = async (id: string) => {
         try{
             await api.patch(`/tickets/${id}/assign-self`, {})
             onAssign()
-            router.push(`chat?id=${group.id}`)
+            router.push(`/chat?id=${id}`)
         }
         catch(err: any) {
             console.error('Erro ao atribuir o atendente', err)
@@ -88,6 +108,19 @@ export default function Page({group, tickets, description, onAssign}: GroupTable
                 pagination={false}
                 tableLayout="fixed"
                 sticky
+                onRow={(record) => ({
+                    onClick: () => {
+                        if (!record.agentId || record.agentId !== currentAgentId) {
+                            return
+                        }
+                        router.push(`/chat?id=${record.id}`)
+                    },
+                })}
+                rowClassName={(record) =>
+                    record.agentId && record.agentId === currentAgentId
+                        ? "cursor-pointer"
+                        : "cursor-default"
+                }
             />
         </section>
     )

--- a/app/(agent)/tickets/hooks/useTicket.tsx
+++ b/app/(agent)/tickets/hooks/useTicket.tsx
@@ -1,16 +1,29 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "@/services/api";
 import { ITicket } from "@/services/ticket/ticket.interface";
 import { ISupportGroupSummary } from "@/services/support-group/support-group.interface";
+
+const POLL_INTERVAL_MS = 15000;
+const DEFAULT_LIMIT = 100;
 
 export default function useTicket() {
     const [tickets, setTickets] = useState<ITicket[]>([]);
     const [groups, setGroups] = useState<ISupportGroupSummary[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
 
-    const fetchTickets = async () => { 
-        try{
-            const res = await api.get('/tickets')
+    const fetchTickets = useCallback(async (options?: { silent?: boolean }) => {
+        const silent = options?.silent ?? false;
+
+        if (!silent) {
+            setLoading(true);
+        }
+
+        try {
+            const res = await api.get('/tickets', {
+                params: {
+                    limit: DEFAULT_LIMIT,
+                },
+            });
             const closedStatus = ['RESOLVED', 'CLOSED']
 
             const openedTickets = res.data.data.filter(
@@ -24,13 +37,23 @@ export default function useTicket() {
             setTickets([])
         }
         finally {
-            setLoading(false)
+            if (!silent) {
+                setLoading(false)
+            }
         }
-    }
+    }, [])
 
     useEffect(() => {
         fetchTickets()
-    }, [])
+    }, [fetchTickets])
+
+    useEffect(() => {
+        const intervalId = setInterval(() => {
+            fetchTickets({ silent: true })
+        }, POLL_INTERVAL_MS)
+
+        return () => clearInterval(intervalId)
+    }, [fetchTickets])
 
     useEffect(() => {
         const uniqueGroup = Array.from(

--- a/app/(agent)/tickets/tickets.table.config.tsx
+++ b/app/(agent)/tickets/tickets.table.config.tsx
@@ -1,6 +1,6 @@
 import type { ColumnsType } from "antd/es/table";
 
-export const getColumns = (onAssign: () => void): ColumnsType<any> => [
+export const getColumns = (onAssign: (ticketId: string) => void): ColumnsType<any> => [
     {
         title: "ID",
         dataIndex: "id",
@@ -58,13 +58,16 @@ export const getColumns = (onAssign: () => void): ColumnsType<any> => [
             if(record.agent) {
                 return (
                     <span className="text-sm font-regular text-black-base">
-                        {record.agent.name}                            
+                        {record.agent.user?.name ?? record.agent.id}                            
                     </span>
                 )
             }
             return(
                 <button
-                    onClick={() => onAssign(record.id)}
+                    onClick={(event) => {
+                        event.stopPropagation()
+                        onAssign(record.id)
+                    }}
                     className="px-3 py-1.5 text-sm bg-white-500 text-black-base rounded-md cursor-pointer hover:bg-blue-base hover:text-white-300 hover:scale-103 transition-all"
                 >
                     Atribuir a mim

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-qr-code": "^2.0.18",
+        "socket.io-client": "^4.8.1",
         "sonner": "^2.0.7"
       },
       "devDependencies": {
@@ -172,7 +173,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2249,6 +2249,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2660,7 +2666,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2720,7 +2725,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3278,7 +3282,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3719,7 +3722,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3981,7 +3983,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4095,14 +4096,12 @@
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4218,6 +4217,28 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -4436,7 +4457,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4622,7 +4642,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6411,7 +6430,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6931,7 +6949,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6941,7 +6958,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7374,6 +7390,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -7688,7 +7732,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7851,7 +7894,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8110,6 +8152,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8136,7 +8207,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-qr-code": "^2.0.18",
+    "socket.io-client": "^4.8.1",
     "sonner": "^2.0.7"
   },
   "devDependencies": {

--- a/services/ticket/ticket.interface.ts
+++ b/services/ticket/ticket.interface.ts
@@ -2,6 +2,13 @@ import { ISupportGroupSummary } from "@/services/support-group/support-group.int
 import { ICompanySummary } from "@/services/company/company.interface"
 import { IUserSummary } from "@/services/user/user.interface"
 import { ITicketSubjectSummary } from "../ticket-subject/ticket-subject.interface";
+import { SupportLevel } from "@/services/user/user.type";
+
+export interface ITicketAgentSummary {
+    id: string;
+    supportLevel: SupportLevel;
+    user: IUserSummary;
+}
 
 export interface ITicket { 
     id: string;
@@ -21,7 +28,7 @@ export interface ITicket {
     isArchived: boolean;
 
     client: IUserSummary;
-    agent: IUserSummary | null;
+    agent: ITicketAgentSummary | null;
     company: ICompanySummary;
     subject: ITicketSubjectSummary;
     supportGroup: ISupportGroupSummary;


### PR DESCRIPTION
## 🎯 Objetivo
Levar a experiência web do agente para um fluxo real de tickets e chat, reaproveitando a rota `/chat`, a listagem de `/tickets` e o componente `Speechbubble`, com atualização automática silenciosa e integração em tempo real.

---

## 📋 Changelog
- Adicionado polling silencioso na listagem de tickets para detectar novos chamados em background.
- Corrigida a navegação de auto-atribuição para abrir o chat do ticket correto.
- Passado a exibir o nome do agente atribuído na coluna “Atribuído à”.
- Ajustada a tipagem do ticket para refletir o relacionamento do agente com `user.name`.
- Integrado Socket.IO na rota de chat para consumir histórico e novas mensagens em tempo real.
- Implementado fechamento do ticket com limpeza de socket, estado local e redirecionamento.

## 🧪 Como testar
1. Subir o frontend e entrar como agente autenticado.
2. Abrir `/tickets` e confirmar que os chamados do grupo aparecem com atualização automática.
3. Assumir um ticket livre e verificar que o chat abre com o ticket correto.
4. Enviar mensagens no chat e validar atualização em tempo real.
5. Conferir que a coluna “Atribuído à” mostra o nome do agente associado.
> Fluxo Completo:
1. Subir os três repositorios, back, front e mobile.
2. Logar no mobile com client@client.com
3. abrir um chamado com qualquer regra de triagem
4. ficar na tela de waiting (aguardando um atendente)
5. Logar no front web com agent@agent.com
6. ir para /tickets, ou chamados na navbar
7. verificar se o ticket foi criado
8. clicar em assumir ticket
9. testar mensagens
10. testar o concluir chamado

---

## 👀 Observações
- A listagem continua baseada na API existente de tickets, sem introduzir cache novo ou gerenciador de estado externo.
- O chat foi mantido visualmente consistente com a estrutura já existente da rota `/chat`.
