### PR TITLE
170-file-preview

### DIFF
--- a/app/(agent)/chat/components/filePreview.tsx
+++ b/app/(agent)/chat/components/filePreview.tsx
@@ -1,0 +1,61 @@
+import { start } from "repl";
+
+interface FilePreviewProps {
+    file: File;
+    onSubmit?: (file: File) => void;
+    onCancel?: () => void;
+    open: boolean;
+}
+
+export default function FilePreview({file, onSubmit, onCancel, open}: FilePreviewProps) {
+    if (!open) return null;
+
+    const typeToIcon = (fileType: string) => {
+        if (fileType === 'application/pdf') return 'bi bi-file-earmark-pdf-fill text-orange-base'
+        if (fileType.startsWith('application/vnd.openxmlformats-officedocument.spreadsheet')) return 'bi bi-file-earmark-spreadsheet-fill text-green-base'
+        if (fileType.startsWith('application/vnd.openxmlformats-officedocument.wordprocessing')) return 'bi bi-file-earmark-word-fill text-blue-base'
+        if (fileType.startsWith('text/')) return 'bi bi-file-earmark-text-fill text-black-300'
+        if (fileType === 'application/zip' || fileType === 'application/x-compressed' || fileType === 'application/x-7z-compressed' )  return 'bi bi-file-earmark-zip-fill text-orange-300'
+        if (fileType.startsWith('application/x-msdownload')) return 'bi bi-file-earmark-code-fill text-teal-base'
+        return 'bi bi-file-earmark-fill text-black-base'
+    };
+
+    return (
+        <div className="flex flex-col justify-center items-center gap-4 p-4 bg-white-base rounded-lg shadow-md w-full h-full top-0 left-0 absolute z-10">
+            <div>
+                <p className="label-2 font-light"> Arquivo Selecionado:</p>
+            </div>
+
+
+            {file.type.startsWith("image/") ? (
+                <>
+                    <p className="label-1 font-medium">{file.name}</p>
+                
+                    <img src={URL.createObjectURL(file)} alt={file.name} className="max-w-xxl max-h-100 rounded" />
+                </>
+            ): (
+                <div className="flex gap-3 py-4 px-3 bg-white-300 rounded border border-white-700">
+
+                    <i className={`${typeToIcon(file.type)} text-6xl`}></i>
+
+                    <div className="flex flex-col gap-1">
+                        <p className="label-1 font-medium text-ellipsis overflow-hidden whitespace-nowrap w-xs text-left">
+                            {file.name}
+                        </p>
+                        <p className="label-2 font-light text-left">
+                            {Math.round(file.size / 1024)} KB
+                        </p>
+                    </div>
+                </div>
+            )}
+
+
+            <div className="flex gap-4">
+                <button
+                    className="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition"
+                    onClick={onCancel}
+                >Cancelar</button>
+            </div>
+        </div>
+    )
+}

--- a/app/(agent)/chat/components/filePreview.tsx
+++ b/app/(agent)/chat/components/filePreview.tsx
@@ -1,61 +1,110 @@
-import { start } from "repl";
+import { useEffect, useState } from "react";
+import typeToIcon from "../utils/TypeToIcon";
+import { X, Send, Plus } from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import prettyBytes from "pretty-bytes";
 
 interface FilePreviewProps {
-    file: File;
-    onSubmit?: (file: File) => void;
-    onCancel?: () => void;
-    open: boolean;
+    files: File[]
+    onSubmit?: () => void
+    onCancel?: () => void
+    removeFile: (index: number) => void
+    filesLimit: number
 }
 
-export default function FilePreview({file, onSubmit, onCancel, open}: FilePreviewProps) {
-    if (!open) return null;
-
-    const typeToIcon = (fileType: string) => {
-        if (fileType === 'application/pdf') return 'bi bi-file-earmark-pdf-fill text-orange-base'
-        if (fileType.startsWith('application/vnd.openxmlformats-officedocument.spreadsheet')) return 'bi bi-file-earmark-spreadsheet-fill text-green-base'
-        if (fileType.startsWith('application/vnd.openxmlformats-officedocument.wordprocessing')) return 'bi bi-file-earmark-word-fill text-blue-base'
-        if (fileType.startsWith('text/')) return 'bi bi-file-earmark-text-fill text-black-300'
-        if (fileType === 'application/zip' || fileType === 'application/x-compressed' || fileType === 'application/x-7z-compressed' )  return 'bi bi-file-earmark-zip-fill text-orange-300'
-        if (fileType.startsWith('application/x-msdownload')) return 'bi bi-file-earmark-code-fill text-teal-base'
-        return 'bi bi-file-earmark-fill text-black-base'
-    };
+export default function FilePreview({files, onSubmit, onCancel, removeFile, filesLimit}: FilePreviewProps) {
+    const [currentFile, setCurrentFile] = useState(0)
+    
+    
+    useEffect(() => {
+        if (currentFile >= files.length){
+            setCurrentFile(Math.max(0, files.length - 1))
+        }
+    }, [files, currentFile])
+    
+    
+    const selectedFile = files[currentFile]
+    
+    if (!selectedFile) return null
 
     return (
         <div className="flex flex-col justify-center items-center gap-4 p-4 bg-white-base rounded-lg shadow-md w-full h-full top-0 left-0 absolute z-10">
-            <div>
-                <p className="label-2 font-light"> Arquivo Selecionado:</p>
-            </div>
+            
+            <header className="absolute top-0 right-0 left-0 justify-end flex p-4">
+                <Button
+                    label='Cancelar Seleção'
+                    className="bg-black-300!"
+                    onClick={onCancel}
+                />
+            </header>
 
+            <section>
+                <p className="label-2 font-light mb-2"> Arquivo Selecionado:</p>
+            
+                <div className="flex flex-col items-center gap-5 p-5 bg-white-300 rounded border border-white-700">
 
-            {file.type.startsWith("image/") ? (
-                <>
-                    <p className="label-1 font-medium">{file.name}</p>
-                
-                    <img src={URL.createObjectURL(file)} alt={file.name} className="max-w-xxl max-h-100 rounded" />
-                </>
-            ): (
-                <div className="flex gap-3 py-4 px-3 bg-white-300 rounded border border-white-700">
-
-                    <i className={`${typeToIcon(file.type)} text-6xl`}></i>
-
-                    <div className="flex flex-col gap-1">
-                        <p className="label-1 font-medium text-ellipsis overflow-hidden whitespace-nowrap w-xs text-left">
-                            {file.name}
+                    {selectedFile.type.startsWith("image/") ? (
+                        <img src={URL.createObjectURL(selectedFile)} alt={selectedFile.name} className="max-w-xxl max-h-80 rounded" />
+                    ): (
+                        <i className={`${typeToIcon(selectedFile.type).icon} text-6xl text-black-300`}></i>
+                    )}
+                        
+                    <div>
+                        <p className="label-1 font-medium text-ellipsis overflow-hidden whitespace-nowrap w-sm text-center text-black-base">
+                            {selectedFile.name}
                         </p>
-                        <p className="label-2 font-light text-left">
-                            {Math.round(file.size / 1024)} KB
+
+                        <p className="label-2 text-center text-black-300">
+                            {prettyBytes(selectedFile.size, {space: false})} - {selectedFile.name.split('.').pop()?.toUpperCase()}
                         </p>
                     </div>
                 </div>
-            )}
+            </section>
 
 
-            <div className="flex gap-4">
-                <button
-                    className="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition"
-                    onClick={onCancel}
-                >Cancelar</button>
-            </div>
+            <header className="flex justify-between items-center absolute bottom-0 p-3 gap-2  w-full border-t border-white-700 bg-white-300">
+
+                <div className="flex gap-2 items-center">
+                    {files.length < filesLimit && (
+                        <label htmlFor="fileInput" className="bg-white-500 aspect-square! border border-white-700 rounded cursor-pointer transition-all text-black-300 hover:bg-teal-base hover:text-beige-300 h-15 flex items-center justify-center" onClick={() => {}}>
+                            <Plus strokeWidth={3}/>
+                        </label>
+                    )}
+
+                    {files.map((f, index) => {
+                        const {icon, color} = typeToIcon(f.type)
+
+                        return (
+                            <div key={f.name + index} className="bg-white-base aspect-square! border border-white-700 rounded cursor-pointer relative transition-all group hover:brightness-85 h-15 flex items-center justify-center" onClick={() => setCurrentFile(index)}>
+                                
+                                {f.type.startsWith('image/') 
+                                    ? <img src={URL.createObjectURL(f)} alt={f.name} className="rounded max-h-full" />
+                                    : <i className={`${icon} ${color} text-4xl`}/> }
+                                
+
+                                <button className="aspect-square! opacity-0 p-1 text-black-700 cursor-pointer absolute top-0 right-0 transition-all group-hover:opacity-100" onClick={() => removeFile(index)}>
+                                    <X size={14} strokeWidth={3}/>
+                                </button>
+                            </div>
+                        )
+                    })}
+
+                    {files.length >= filesLimit && (
+                        <p className="label-2 text-red-700 font-medium">Limite de {filesLimit} arquivos atingido!</p>
+                    )}
+                </div>
+
+                
+                <Button
+                    icon={Send}
+                    type="button"
+                    className="bg-blue-base! aspect-square!"
+                    onClick={onSubmit}
+                />
+            </header>
+
+
+
         </div>
     )
 }

--- a/app/(agent)/chat/page.tsx
+++ b/app/(agent)/chat/page.tsx
@@ -7,11 +7,12 @@ import { io, Socket } from "socket.io-client";
 import Speechbubble from "./components/speechbubble/speechbubble";
 import { InputField } from "@/app/components/ui/inputField";
 import { Button } from "@/app/components/ui/button";
-import { Send } from "lucide-react";
+import { Send, Paperclip } from "lucide-react";
 import { api } from "@/services/api";
 import { decodeToken } from "@/utils/decode-token";
 import { ITicket } from "@/services/ticket/ticket.interface";
 import { Modal } from "@/app/components/ui/modal";
+import FilePreview from "./components/filePreview";
 
 type ChatMessage = {
     id: string;
@@ -34,6 +35,7 @@ export default function Page() {
     const [ticket, setTicket] = useState<ITicket | null>(null);
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [messageInput, setMessageInput] = useState("");
+    const [fileInput, setFileInput] = useState<File | null>(null);
     const [authToken, setAuthToken] = useState<string | null>(null);
     const [currentAgentId, setCurrentAgentId] = useState<string | null>(null);
     const socketRef = useRef<Socket | null>(null);
@@ -46,6 +48,10 @@ export default function Page() {
     useEffect(() => {
         chatEndRef.current?.scrollIntoView({behavior: 'smooth'})
     }, [messages])
+
+    useEffect(() => {
+        console.log(fileInput)
+    }, [fileInput])
 
     useEffect(() => {
         const token = Cookies.get("token") || localStorage.getItem("token");
@@ -196,7 +202,7 @@ export default function Page() {
     };
 
     return (
-        <div className="h-screen flex flex-col items-center bg-white-base">
+        <div className="h-screen flex flex-col items-center bg-white-base relative">
             <header className="bg-white-500 w-full p-4 flex justify-between shadow-sm/15 z-1">
                 <h4 className='text-1 align-middle flex items-center'>
                     {ticket?.client?.name ?? "Cliente"}
@@ -270,11 +276,21 @@ export default function Page() {
                 </section>
 
             </section>
+            
 
             <header className="bg-white-base w-full px-4 py-3 flex items-center gap-2.5">
+                <input type="file" className="hidden" id="fileInput" onChange={(e) => setFileInput(e.target.files?.[0] || null)} />
+                <label
+                    className=" aspect-square! rounded-lg! bg-white-700 text-white-300 h-full flex justify-center items-center cursor-pointer! hover:bg-teal-base transition"
+                    htmlFor="fileInput"
+                >
+                    <Paperclip />
+                </label>
+
+
                 <InputField
                     placeholder="Digite sua mensagem"
-                    className="bg-white-base focus:ring-[var(--blue-300)]!"
+                    className="bg-white-300 focus:ring-[var(--blue-300)]!"
                     value={messageInput}
                     onChange={(event) => setMessageInput(event.target.value)}
                     onKeyDown={(e) => {
@@ -291,6 +307,13 @@ export default function Page() {
                     onClick={handleSend}
                 />
             </header>
+
+            <FilePreview                
+                file={fileInput!}
+                open={!!fileInput}
+                onCancel={() => setFileInput(null)}
+            />
+
         </div>
     )
 }

--- a/app/(agent)/chat/page.tsx
+++ b/app/(agent)/chat/page.tsx
@@ -35,7 +35,8 @@ export default function Page() {
     const [ticket, setTicket] = useState<ITicket | null>(null);
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [messageInput, setMessageInput] = useState("");
-    const [fileInput, setFileInput] = useState<File | null>(null);
+    const [fileInput, setFileInput] = useState<File[]>([])
+    const FILES_LIMIT = 5 // Limites de arquivos que podem ser enviados por vez
     const [authToken, setAuthToken] = useState<string | null>(null);
     const [currentAgentId, setCurrentAgentId] = useState<string | null>(null);
     const socketRef = useRef<Socket | null>(null);
@@ -44,6 +45,16 @@ export default function Page() {
     const [loadingClose, setLoadingClose] = useState(false);
 
     const chatEndRef = useRef<HTMLDivElement | null>(null)
+
+    const handleRemoveFile = (index: number): void => {
+        setFileInput(prev => prev?.filter((_, i) => i !== index))
+    }
+
+    const handleAddFiles = (files: File[]): void => {
+        setFileInput(prev => 
+            [...prev, ...files].slice(0, FILES_LIMIT)
+        )
+    }
     
     useEffect(() => {
         chatEndRef.current?.scrollIntoView({behavior: 'smooth'})
@@ -202,7 +213,7 @@ export default function Page() {
     };
 
     return (
-        <div className="h-screen flex flex-col items-center bg-white-base relative">
+        <div className="h-screen flex flex-col items-center  bg-white-base relative">
             <header className="bg-white-500 w-full p-4 flex justify-between shadow-sm/15 z-1">
                 <h4 className='text-1 align-middle flex items-center'>
                     {ticket?.client?.name ?? "Cliente"}
@@ -279,12 +290,18 @@ export default function Page() {
             
 
             <header className="bg-white-base w-full px-4 py-3 flex items-center gap-2.5">
-                <input type="file" className="hidden" id="fileInput" onChange={(e) => setFileInput(e.target.files?.[0] || null)} />
+                <input type="file" multiple className="hidden" id="fileInput" 
+                    onChange={(e) => {
+                        const files = Array.from(e.target.files ?? [] )
+                        handleAddFiles(files)
+                        e.target.value = ''
+                    }} 
+                />
                 <label
-                    className=" aspect-square! rounded-lg! bg-white-700 text-white-300 h-full flex justify-center items-center cursor-pointer! hover:bg-teal-base transition"
+                    className=" aspect-square! rounded-lg! bg-white-500 text-black-300/50 h-full flex justify-center items-center cursor-pointer! hover:bg-teal-500 hover:text-beige-300 transition"
                     htmlFor="fileInput"
                 >
-                    <Paperclip />
+                    <Paperclip/>
                 </label>
 
 
@@ -309,9 +326,10 @@ export default function Page() {
             </header>
 
             <FilePreview                
-                file={fileInput!}
-                open={!!fileInput}
-                onCancel={() => setFileInput(null)}
+                files={fileInput}
+                onCancel={() => setFileInput([])}
+                removeFile={handleRemoveFile}
+                filesLimit={FILES_LIMIT}
             />
 
         </div>

--- a/app/(agent)/chat/utils/TypeToIcon.ts
+++ b/app/(agent)/chat/utils/TypeToIcon.ts
@@ -1,0 +1,73 @@
+export default function typeToIcon(mimeType: string): {icon: string, color: string} {
+
+    let res = {
+        icon: 'bi bi-file-earmark-fill',
+        color: 'text-black-300'
+    }
+
+    // vídeo
+    if (/^video\//.test(mimeType)){
+        res.icon    = 'bi bi-file-earmark-play-fill'
+        res.color = 'text-teal-base'
+    }
+    // áudio
+    else if (/^audio\//.test(mimeType)) {
+        res.icon = 'bi bi-file-earmark-music-fill';
+        res.color = 'text-teal-base';
+    }
+
+    // texto
+    else if (/^text\//.test(mimeType)) {
+        res.icon = 'bi bi-file-earmark-text-fill';
+    }
+
+    // pdf
+    else if (/pdf/.test(mimeType)) {
+        res.icon = 'bi bi-file-earmark-pdf-fill';
+        res.color = 'text-red-base';
+    }
+
+    // word
+    else if (/word|wordprocessingml/.test(mimeType)) {
+        res.icon = 'bi bi-file-earmark-word-fill';
+        res.color = 'text-blue-base';
+    }
+
+    // excel / planilhas
+    else if (/excel|spreadsheetml/.test(mimeType)) {
+        res.icon = 'bi bi-file-earmark-spreadsheet-fill';
+        res.color = 'text-green-base';
+    }
+
+    // powerpoint
+    else if (/powerpoint|presentationml/.test(mimeType)) {
+        res.icon = 'bi bi-file-earmark-slides-fill';
+        res.color = 'text-orange-300';
+    }
+
+    // compactados
+    else if (
+        /zip|rar|7z|gzip|tar|compressed/.test(mimeType)
+    ) {
+        res.icon = 'bi bi-file-earmark-zip-fill';
+        res.color = 'text-orange-base';
+    }
+
+    // código / scripts
+    else if (
+        /javascript|typescript|python|php|json|xml|html|css|java|x-c/.test(mimeType)
+    ) {
+        res.icon = 'bi bi-file-earmark-code-fill';
+        res.color = 'text-blue-500';
+    }
+
+    // executáveis
+    else if (
+        /x-msdownload|octet-stream|x-executable/.test(mimeType)
+    ) {
+        res.icon = 'bi bi-file-earmark-binary-fill';
+        res.color = 'text-teal-500';
+    }
+
+    return res
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jwt-decode": "^4.0.0",
         "lucide-react": "^1.7.0",
         "next": "16.1.6",
+        "pretty-bytes": "^7.1.0",
         "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -6876,6 +6877,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
+      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jwt-decode": "^4.0.0",
     "lucide-react": "^1.7.0",
     "next": "16.1.6",
+    "pretty-bytes": "^7.1.0",
     "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
## 🎯 Objetivo

<!-- Explique por que este PR foi criado e qual seu propósito central.

Exemplos:

- Implementação do módulo de chat via WebSocket
- Correção do escalonamento entre grupos de atendimento
- Refatoração da lógica de triagem automatizada -->
- Visualizar os arquivos selecionados pelo atendente no chat
- Remover e adicionar vários arquivos selecionados


## 📋 Changelog

<!-- Lista técnica das mudanças:

- arquivos alterados
- comportamento modificado
- regras adicionadas
- refatorações feitas -->
- Criação do componente filePreview.tsx 
- Criação da função typeToIcon para retornar ícones de acordo com o mime type do arquivo
- Instalação da biblioteca PrettyBytes para exibir tamanho de arquivos

## 🧪 Como testar

<!-- Passo a passo claro para o revisor validar: -->

1. ```npm install``` e ```npm run dev```
2. Através de /tickets, entre em um chat que o atendente logado esteja atribuído
3. Clique no ícone de clip ao lado esquerdo do input de mensagem
4. Selecione um ou vários arquivos
5. Visualize os arquivos selecionados clicando nele na tela aberta
6. Remova e adicione novos arquivos
7. Tente passar do limite padrão de 5 arquivos selecionados