### PR TITLE
feat: PT-171 adiciona upload e visualização da logo da empresa

### DIFF
--- a/app/(admin)/manage-companies/page.tsx
+++ b/app/(admin)/manage-companies/page.tsx
@@ -29,6 +29,7 @@ export default function Page() {
     name: "",
     contactName: "",
     contactEmail: "",
+    logoUrl: "",
   });
   const [loadingModal, setLoadingModal] = useState(false);
   const [error, setError] = useState("");
@@ -51,14 +52,15 @@ export default function Page() {
     try {
       if (editingId) {
 
-        const { cnpj, ...updateData } = form; 
+        const { cnpj, logoUrl, ...updateData } = form; 
         await handleUpdate(editingId, updateData); 
 
         if (logoFile) {
           await uploadCompanyLogo(editingId, logoFile);
         }
       } else {
-        const created = await handleCreate(form); 
+        const { logoUrl, ...createData } = form;
+        const created = await handleCreate(createData); 
         if (created?.id && logoFile) {
           await uploadCompanyLogo(created.id, logoFile);
         }
@@ -67,7 +69,7 @@ export default function Page() {
       refresh();
       setIsModalOpen(false);
       setEditingId(null);
-      setForm({ cnpj: "", name: "", contactName: "", contactEmail: "" });
+      setForm({ cnpj: "", name: "", contactName: "", contactEmail: "", logoUrl: "" });
       setLogoFile(null);
     } catch (err: any) {
       setError("Erro ao processar requisição.");
@@ -83,6 +85,7 @@ export default function Page() {
       name: company.name,
       contactName: company.contactName,
       contactEmail: company.contactEmail,
+      logoUrl: company.logoUrl ?? "",
     });
     setLogoFile(null);
     setIsModalOpen(true);
@@ -159,8 +162,9 @@ export default function Page() {
           <Button
             onClick={() => {
               setEditingId(null); 
-              setForm({ cnpj: "", name: "", contactName: "", contactEmail: "" }); 
+              setForm({ cnpj: "", name: "", contactName: "", contactEmail: "", logoUrl: "" }); 
               setIsModalOpen(true); 
+              setLogoFile(null);
             }}
             label="Adicionar"
             icon={Plus}
@@ -207,7 +211,7 @@ export default function Page() {
         onClose={() => {
           setIsModalOpen(false);
           setEditingId(null);
-          setForm({ cnpj: "", name: "", contactName: "", contactEmail: "" });
+          setForm({ cnpj: "", name: "", contactName: "", contactEmail: "", logoUrl: "" });
           setLogoFile(null);
         }}
         title={editingId ? "Editar Empresa" : "Nova Empresa"}
@@ -288,6 +292,13 @@ export default function Page() {
           <label className="text-xs font-semibold text-black-300 uppercase tracking-wide">
             Logo da Empresa (opcional)
           </label>
+          {(logoFile || form.logoUrl) && (
+            <img
+              src={logoFile ? URL.createObjectURL(logoFile) : form.logoUrl}
+              alt="Preview"
+              className="w-16 h-16 rounded-xl object-cover border border-white-700 bg-white mb-2"
+            />
+          )}
           <input
             type="file"
             accept="image/*"


### PR DESCRIPTION
## 🎯 Objetivo

Implementação do upload e visualização de logos de empresas na interface de gerenciamento de empresas.

```
resolves PT-171
```

---

## 📋 Changelog

1. Modificado o arquivo de gerenciamento de empresas no front-end (app/(admin)/manage-companies/page.tsx).

- Adicionado o campo logoUrl no estado inicial do formulário
- Reset do estado da logoUrl e do logoFile ao fechar ou submeter o modal
- Mapeamento da logoUrl da empresa ao abrir o formulário em modo de edição
- Inserção da tag img para exibir o preview dinâmico ou a logo vinda do banco

## 🧪 Como testar

1. Certifique-se de que o back-end está rodando e os containers do Docker (PostgreSQL e MinIO) estão ativos.

2. Acesse a interface do front-end na rota de gerenciamento de empresas.

3. Clique no ícone de Editar de uma empresa.

4. Clique em Choose File, selecione um arquivo de imagem local.

5. Clique no botão de Salvar; e deve aparecer uma mensagem verde de sucesso.

6. Clique novamente no botão de Editar a empresa e verifique se a logo salva carrega.
