### PR TITLE
feat: Adicionei a funcionalidade de colocar uma foto padrão para o cl…

### DIFF
--- a/app/(agent)/chat/page.tsx
+++ b/app/(agent)/chat/page.tsx
@@ -193,6 +193,7 @@ export default function Page() {
   }, [messages]);
 
   const isClosed = ticket?.status === "CLOSED" || ticket?.status === "RESOLVED";
+  const clientAvatarUrl = ticket?.client?.avatarUrl ?? ticket?.company?.logoUrl;
 
   const handleSend = () => {
     if (!ticketId) {
@@ -292,7 +293,7 @@ export default function Page() {
       <header className="bg-white-500 w-full p-4 flex justify-between shadow-sm/15 z-1">
         <div className="flex justify-center items-center gap-3">
                     
-            <Avatar src={ticket?.client?.avatarUrl} alt="Foto da empresa do Cliente" className="w-10" />
+            <Avatar src={clientAvatarUrl} alt="Foto da empresa do Cliente" className="w-10" />
 
             <h4 className="text-1 align-middle flex items-center">
               {ticket?.client?.name ?? "Cliente"}
@@ -434,7 +435,7 @@ export default function Page() {
         <section className="px-2 py-6 flex flex-col gap-1.5 max-w-4xl w-full">    
             <div className="flex flex-col items-center">
 
-                <Avatar src={ticket?.client?.avatarUrl} alt="Foto da Empresa do Cliente" className="w-40 object-cover mb-3 border-3" />
+                <Avatar src={clientAvatarUrl} alt="Foto da Empresa do Cliente" className="w-40 object-cover mb-3 border-3" />
 
                 <h6 className="label-2">
                     Você está atendendo
@@ -481,7 +482,7 @@ export default function Page() {
               date={message.createdAt}
               message={message.deletedAt ? "Mensagem removida" : message.content}
               attachments={message.deletedAt ? [] : message.attachments}
-              pfp={message.senderId === currentAgentId ? ticket?.agent?.user?.avatarUrl : ticket?.client?.avatarUrl}
+              pfp={message.senderId === currentAgentId ? ticket?.agent?.user?.avatarUrl : clientAvatarUrl}
             />
           ))}
 

--- a/app/components/layout/sidebarAgent.tsx
+++ b/app/components/layout/sidebarAgent.tsx
@@ -200,7 +200,7 @@ export function SidebarAgent({ client }: SidebarAgentProps) {
                   >
                     <div className="bg-white-base p-1 rounded-full overflow-hidden w-10 h-10 flex-shrink-0">
                       <img
-                        src={client.avatarUrl || "/icons/personFill.svg"}
+                        src={ticket.client?.avatarUrl ?? ticket.company?.logoUrl ?? client.avatarUrl ?? "/icons/personFill.svg"}
                         alt="Foto do Cliente"
                         className="w-full h-full object-cover"
                       />

--- a/services/company/company.interface.ts
+++ b/services/company/company.interface.ts
@@ -24,4 +24,4 @@ export interface ICompanyResponse {
 
 export type ICompanyCreateRequest = Omit<ICompany, "id">;
 export type ICompanyUpdateRequest = Partial<ICompanyCreateRequest> & { id: string };
-export type ICompanySummary = Pick<ICompany, "id" | "name">
+export type ICompanySummary = Pick<ICompany, "id" | "name" | "logoUrl">


### PR DESCRIPTION
## 🎯 Objetivo

- Implementação da foto padrão para o cliente que recém criou a conta ser a mesma da empresa
- Se a empresa mudar a própria foto, também muda a foto do perfil para o cliente

Vincule tarefas do Jira ou issues do GitHub:

```
[7] Foto de perfil padrão do Cliente
```
---

## 📋 Changelog

- Eu alterei o backend, frontend e o mobile
- No backend:
1. src/modules/company/company.repository.ts
2. src/modules/company/company.service.ts
3. src/modules/ticket/dtos/response-ticket.dto.ts
4. src/modules/ticket/ticket.repository.ts
5. src/modules/user/user.repository.ts
6. src/modules/user/user.service.ts
- No frontend:
1. app/(agent)/chat/page.tsx
2. app/components/layout/sidebarAgent.tsx
3. services/company/company.interface.ts
- No mobile:
1. app/(agent)/chat.tsx
2. components/TicketCard/ticketcard.tsx
3. services/ticket.ts

## 🧪 Como testar 

<!-- Passo a passo claro para o revisor validar: -->

1. Rode o backend, o frontend e o mobile
2. Entre como admin, vá em Empresas e coloque um logo para a empresa que você queira alterar.
3. Veja a alteração no chat do cliente